### PR TITLE
Added: dynamic images (JPG/PNG) generator with SSRF token

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is an SSRF testing sheriff written in Go. It was originally created for the
 
 ## Features
 
-- Repsond to any HTTP method (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+- Respond to any HTTP method (`GET`, `POST`, `PUT`, `DELETE`, etc.)
 - Configurable secret token (see [base.example.yaml](config/base.example.yaml))
 - Content-specific responses
   - With secret token in response body
@@ -14,10 +14,10 @@ This is an SSRF testing sheriff written in Go. It was originally created for the
     - HTML
     - CSV
     - TXT
-  - Without token in response body
-    - GIF
     - PNG
     - JPEG
+  - Without token in response body
+    - GIF
     - MP3
     - MP4
 
@@ -63,8 +63,6 @@ Content-Length: 81
 
 - Dynamically generate valid responses with the secret token visible for
   - GIF
-  - PNG
-  - JPEG
   - MP3
   - MP4
 - Secrets in HTTP response generated/created/signed per-request, instead of returning a single secret for all requests

--- a/generators/images.go
+++ b/generators/images.go
@@ -1,0 +1,32 @@
+package generators
+
+import (
+	"github.com/fogleman/gg"
+	"github.com/golang/freetype/truetype"
+	"golang.org/x/image/font/gofont/goregular"
+)
+
+// function that generates JPG and PNG images with the provided text
+// and save them into "/templates" directory
+func GenerateJPGAndPNG(ssrfToken string) {
+	const W = 1024
+	const H = 768
+
+	dc := gg.NewContext(W, H)
+	dc.SetRGB(0, 0, 0)
+	dc.Clear()
+	dc.SetRGB(1, 1, 1)
+	font, err := truetype.Parse(goregular.TTF)
+	if err != nil {
+		panic("")
+	}
+	face := truetype.NewFace(font, &truetype.Options{
+		Size: 14,
+	})
+	dc.SetFontFace(face)
+	dc.DrawStringAnchored(ssrfToken,  W/2, H/2, 0.5, 0.5)
+
+
+	dc.SaveJPG("./templates/jpeg.jpg", 80)
+	dc.SavePNG("./templates/png.png")
+}

--- a/generators/init.go
+++ b/generators/init.go
@@ -1,0 +1,6 @@
+package generators
+
+// function that run all media files generators with the provided text
+func InitMediaGenerators(ssrfToken string)  {
+	GenerateJPGAndPNG(ssrfToken)
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/gorilla/mux"
+	"github.com/teknogeek/ssrf-sheriff/generators"
 	"github.com/teknogeek/ssrf-sheriff/httpserver"
 	"go.uber.org/config"
 	"go.uber.org/fx"
@@ -52,6 +53,12 @@ func NewSSRFSheriffRouter(
 	}
 }
 
+// StartFilesGenerator starts the function which is dynamically generating JPG/PNG formats
+// with the secret token rendered in the media
+func StartFilesGenerator(cfg config.Provider) {
+	generators.InitMediaGenerators(cfg.Get("ssrf_token").String())
+}
+
 // StartServer starts the HTTP server
 func StartServer(server *http.Server, lc fx.Lifecycle) {
 	h := httpserver.NewHandle(server)
@@ -82,14 +89,13 @@ func (s *SSRFSheriffRouter) PathHandler(w http.ResponseWriter, r *http.Request) 
 		response = fmt.Sprintf(tmpl, s.ssrfToken)
 	case ".txt":
 		response = fmt.Sprintf("token=%s", s.ssrfToken)
-
-	// TODO: dynamically generate these formats with the secret token rendered in the media
-	case ".gif":
-		response = readTemplateFile("gif.gif")
 	case ".png":
 		response = readTemplateFile("png.png")
 	case ".jpg", ".jpeg":
 		response = readTemplateFile("jpeg.jpg")
+	// TODO: dynamically generate these formats with the secret token rendered in the media
+	case ".gif":
+		response = readTemplateFile("gif.gif")
 	case ".mp3":
 		response = readTemplateFile("mp3.mp3")
 	case ".mp4":

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/ndelphit/ssrf-sheriff/handler"
+	"github.com/teknogeek/ssrf-sheriff/handler"
 	"go.uber.org/fx"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/teknogeek/ssrf-sheriff/handler"
+	"github.com/ndelphit/ssrf-sheriff/handler"
 	"go.uber.org/fx"
 )
 
@@ -18,6 +18,6 @@ func opts() fx.Option {
 			handler.NewServerRouter,
 			handler.NewHTTPServer,
 		),
-		fx.Invoke(handler.StartServer),
+		fx.Invoke(handler.StartFilesGenerator, handler.StartServer),
 	)
 }


### PR DESCRIPTION
Hey @teknogeek 👋

## Motivation
While playing with your utility I noticed that when I send a request to routes:

- `GET` /abc.jpg
- `GET` /abc.gif 

The server is returning an image with `size (1x1)`. And I think it will cool to add as a minimum full-size image in response.

Because in some type of Content-Based SSRF (like in Screenshot / PDF generators ) it is difficult for the attacker to check whether he was able to get an image from the internal infrastructure. If the image only takes 1x1 pixel. In this case, it is easy not to notice that the vulnerability has been successfully exploited.

## Changes

In this pull-request I have added:

- Added: generator which is dynamically generated images (JPG/PNG - 1024/768 size) with SSRF token while utility startup.
- Updated: README.md.